### PR TITLE
fixed currency bug for messages

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -26,6 +26,7 @@ clean-targets: # directories to be removed by `dbt clean`
 
 on-run-start:
   - "{{create_sps()}}"
+  - "{{create_json_merge()}}"
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/macros/json_merge.sql
+++ b/macros/json_merge.sql
@@ -1,0 +1,10 @@
+{% macro create_json_merge() -%}
+CREATE OR REPLACE FUNCTION {{target.database}}.{{target.schema}}.json_merge(o1 VARIANT, o2 VARIANT)
+  RETURNS VARIANT
+  LANGUAGE JAVASCRIPT
+AS
+$$
+  return Object.assign(O1, O2);
+$$
+;
+{%- endmacro %}


### PR DESCRIPTION
# Description

_Please include a summary of changes and related issue (if any)._


# Tests

- [x] Please provide evidence of your successful `dbt run` / `dbt test` here

**dbt run**
```
root@5f1209c62936:/terra/models/silver# dbt run --select silver__messages --full-refresh
06:21:20  Running with dbt=1.2.0
06:21:25  Found 46 models, 130 tests, 0 snapshots, 0 analyses, 682 macros, 1 operation, 0 seed files, 44 sources, 0 exposures, 0 metrics
06:21:25
06:21:39
06:21:39  Running 1 on-run-start hook
06:21:39  1 of 1 START hook: terra.on-run-start.0 ........................................ [RUN]
06:21:39  1 of 1 OK hook: terra.on-run-start.0 ........................................... [OK in 0.00s]
06:21:39
06:21:39  Concurrency: 4 threads (target='dev')
06:21:39
06:21:39  1 of 1 START incremental model silver.messages ................................. [RUN]
06:35:16  1 of 1 OK created incremental model silver.messages ............................ [SUCCESS 1 in 816.90s]
06:35:16
06:35:16  Finished running 1 incremental model, 1 hook in 0 hours 13 minutes and 51.42 seconds (831.42s).
06:35:16
06:35:16  Completed successfully
06:35:16
06:35:16  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

**dbt test**
```
root@b8b5878818cd:/terra/models/silver# dbt test --select silver__messages
12:57:10  Running with dbt=1.2.0
12:57:17  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
12:57:17  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
12:57:17  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
12:57:17  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
12:57:17  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
12:57:17  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
12:57:17  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
12:57:17  Warning: the `dateadd` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `dateadd` 
(no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
12:57:17  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
12:57:18  Found 46 models, 131 tests, 0 snapshots, 0 analyses, 682 macros, 1 operation, 0 seed files, 44 sources, 0 exposures, 0 metrics
12:57:18  
12:57:35  
12:57:35  Running 1 on-run-start hook
12:57:35  1 of 1 START hook: terra.on-run-start.0 ........................................ [RUN]
12:57:35  1 of 1 OK hook: terra.on-run-start.0 ........................................... [OK in 0.00s]
12:57:35
12:57:35  Concurrency: 4 threads (target='dev')
12:57:35
12:57:35  1 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_ATTRIBUTES__OBJECT  [RUN]
12:57:35  2 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_BLOCK_ID__NUMBER__FLOAT  [RUN]
12:57:35  3 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_BLOCK_TIMESTAMP__TIMESTAMP_NTZ  [RUN]
12:57:35  4 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_CHAIN_ID__VARCHAR  [RUN]
12:57:40  4 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_CHAIN_ID__VARCHAR  [PASS in 5.24s]
12:57:40  5 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_ID__STRING__VARCHAR  [RUN]
12:57:40  2 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_BLOCK_ID__NUMBER__FLOAT  [PASS in 5.44s]
12:57:40  6 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_INDEX__NUMBER  [RUN]
12:57:40  3 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_BLOCK_TIMESTAMP__TIMESTAMP_NTZ  [PASS in 5.69s]
12:57:40  7 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_TYPE__VARCHAR  [RUN]
12:57:41  1 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_ATTRIBUTES__OBJECT  [PASS in 5.85s]
12:57:41  8 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_TX_ID__VARCHAR  [RUN]
12:57:44  5 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_ID__STRING__VARCHAR  [PASS in 3.97s]
12:57:44  9 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_TX_SUCCEEDED__BOOLEAN  [RUN]
12:57:44  6 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_INDEX__NUMBER  [PASS in 3.92s]
12:57:44  10 of 20 START test dbt_utils_unique_combination_of_columns_silver__messages_message_id  [RUN]
12:57:44  7 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_TYPE__VARCHAR  [PASS in 3.77s]
12:57:44  11 of 20 START test not_null_silver__messages_ATTRIBUTES ....................... [RUN]
12:57:44  8 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_TX_ID__VARCHAR  [PASS in 3.87s]
12:57:44  12 of 20 START test not_null_silver__messages_BLOCK_ID ......................... [RUN]
12:57:48  9 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_TX_SUCCEEDED__BOOLEAN  [PASS in 4.04s]
12:57:48  12 of 20 PASS not_null_silver__messages_BLOCK_ID ............................... [PASS in 3.54s]
12:57:48  13 of 20 START test not_null_silver__messages_BLOCK_TIMESTAMP .................. [RUN]
12:57:48  14 of 20 START test not_null_silver__messages_CHAIN_ID ......................... [RUN]
12:57:48  10 of 20 PASS dbt_utils_unique_combination_of_columns_silver__messages_message_id  [PASS in 4.36s]
12:57:48  15 of 20 START test not_null_silver__messages_MESSAGE_ID ....................... [RUN]
12:57:49  11 of 20 PASS not_null_silver__messages_ATTRIBUTES ............................. [PASS in 4.83s]
12:57:49  16 of 20 START test not_null_silver__messages_MESSAGE_INDEX .................... [RUN]
12:57:52  14 of 20 PASS not_null_silver__messages_CHAIN_ID ............................... [PASS in 3.71s]
12:57:52  17 of 20 START test not_null_silver__messages_MESSAGE_TYPE ..................... [RUN]
12:57:52  13 of 20 PASS not_null_silver__messages_BLOCK_TIMESTAMP ........................ [PASS in 3.75s]
12:57:52  18 of 20 START test not_null_silver__messages_TX_ID ............................ [RUN]
12:57:52  15 of 20 PASS not_null_silver__messages_MESSAGE_ID ............................. [PASS in 3.45s]
12:57:52  19 of 20 START test not_null_silver__messages_TX_SUCCEEDED ..................... [RUN]
12:57:53  16 of 20 PASS not_null_silver__messages_MESSAGE_INDEX .......................... [PASS in 3.70s]
12:57:53  20 of 20 START test unique_silver__messages_MESSAGE_ID ......................... [RUN]
12:57:56  17 of 20 PASS not_null_silver__messages_MESSAGE_TYPE ........................... [PASS in 3.90s]
12:57:56  19 of 20 PASS not_null_silver__messages_TX_SUCCEEDED ........................... [PASS in 3.74s]
12:57:56  18 of 20 PASS not_null_silver__messages_TX_ID .................................. [PASS in 3.99s]
12:57:57  20 of 20 PASS unique_silver__messages_MESSAGE_ID ............................... [PASS in 3.91s]
12:57:57  
12:57:57  Finished running 20 tests, 1 hook in 0 hours 0 minutes and 39.14 seconds (39.14s).
12:57:57  
12:57:57  Completed successfully
12:57:57
12:57:57  Done. PASS=20 WARN=0 ERROR=0 SKIP=0 TOTAL=20
```
- [ ] Any comparison between `prod` and `dev` for any schema change


# Checklist
- [ ] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [ ] Tag the person(s) responsible for reviewing proposed changes
- [ ] Notes to deployment, if a `full-refresh` is needed for any table
- [ ] Run `git merge main` to pull any changes from remote into your branch prior to merge.
