### PR TITLE
fixed ibc currency bug

### DIFF
--- a/models/silver/silver__messages.sql
+++ b/models/silver/silver__messages.sql
@@ -85,7 +85,7 @@ attributes AS (
             VALUE :key = 'amount',
             REGEXP_SUBSTR(
                 VALUE :value :: STRING,
-                '[A-Za-z]+'
+                '[^[:digit:]](.*)'
             ),
             NULL
         ) AS currency,


### PR DESCRIPTION
# Description

Addresses the IBC currency bug #31


# Tests

- [x] Please provide evidence of your successful `dbt run` / `dbt test` here

**dbt run**
```
root@399e3d9767d6:/terra/models/silver# dbt run --select silver__messages+ --full-refresh 
09:55:28  Running with dbt=1.2.0
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_silver__staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_silver__staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_silver__staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_silver__staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_silver__staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_silver__staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_silver__staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `dateadd` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `dateadd` 
(no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_silver__staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_silver__staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__ez_staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__ez_staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__ez_staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__ez_staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__ez_staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__ez_staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__ez_staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `dateadd` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `dateadd` 
(no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__ez_staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__ez_staking_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `dateadd` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `dateadd` 
(no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:35  Warning: the `type_timestamp` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `type_timestamp` (no prefix) instead. The terra.dbt_expectations_expect_row_values_to_have_recent_data_core__fact_transactions_BLOCK_TIMESTAMP__day__1 model triggered this warning.
09:55:36  Found 48 models, 162 tests, 0 snapshots, 0 analyses, 684 macros, 2 operations, 0 seed files, 44 sources, 0 exposures, 0 metrics
09:55:36  
09:55:53  
09:55:53  Running 2 on-run-start hooks
09:55:54  1 of 2 START hook: terra.on-run-start.0 ........................................ [RUN]
09:55:54  1 of 2 OK hook: terra.on-run-start.0 ........................................... [OK in 0.00s]
09:55:54  2 of 2 START hook: terra.on-run-start.1 ........................................ [RUN]
09:55:55  2 of 2 OK hook: terra.on-run-start.1 ........................................... [SUCCESS 1 in 1.91s]
09:55:55  
09:55:56  Concurrency: 4 threads (target='dev')
09:55:56  
09:55:56  1 of 4 START incremental model silver.messages ................................. [RUN]
10:10:30  1 of 4 OK created incremental model silver.messages ............................ [SUCCESS 1 in 874.09s]
10:10:30  2 of 4 START view model core.fact_messages ..................................... [RUN]
10:10:30  3 of 4 START incremental model silver.staking .................................. [RUN]
10:10:33  2 of 4 OK created view model core.fact_messages ................................ [SUCCESS 1 in 3.21s]
10:10:36  3 of 4 OK created incremental model silver.staking ............................. [SUCCESS 1 in 6.35s]
10:10:36  4 of 4 START view model core.ez_staking ........................................ [RUN]
10:10:39  4 of 4 OK created view model core.ez_staking ................................... [SUCCESS 1 in 2.61s]
10:10:39  
10:10:39  Finished running 2 incremental models, 2 view models, 2 hooks in 0 hours 15 minutes and 3.34 seconds (903.34s).
10:10:39  
10:10:39  Completed successfully
10:10:39
10:10:39  Done. PASS=4 WARN=0 ERROR=0 SKIP=0 TOTAL=4
```

**dbt test**
```
root@399e3d9767d6:/terra/models/silver# dbt test --select silver__messages
10:11:58  Running with dbt=1.2.0
10:12:04  Found 48 models, 162 tests, 0 snapshots, 0 analyses, 684 macros, 2 operations, 0 seed files, 44 sources, 0 exposures, 0 metrics
10:12:04  
10:12:22  
10:12:22  Running 2 on-run-start hooks
10:12:22  1 of 2 START hook: terra.on-run-start.0 ........................................ [RUN]
10:12:22  1 of 2 OK hook: terra.on-run-start.0 ........................................... [OK in 0.00s]
10:12:22  2 of 2 START hook: terra.on-run-start.1 ........................................ [RUN]
10:12:24  2 of 2 OK hook: terra.on-run-start.1 ........................................... [SUCCESS 1 in 2.14s]
10:12:24  
10:12:24  Concurrency: 4 threads (target='dev')
10:12:24  
10:12:25  1 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_ATTRIBUTES__OBJECT  [RUN]
10:12:25  2 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_BLOCK_ID__NUMBER__FLOAT  [RUN]
10:12:25  3 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_BLOCK_TIMESTAMP__TIMESTAMP_NTZ  [RUN]
10:12:25  4 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_CHAIN_ID__VARCHAR  [RUN]
10:12:30  4 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_CHAIN_ID__VARCHAR  [PASS in 5.98s]
10:12:30  5 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_ID__STRING__VARCHAR  [RUN]
10:12:31  3 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_BLOCK_TIMESTAMP__TIMESTAMP_NTZ  [PASS in 6.11s]
10:12:31  6 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_INDEX__NUMBER  [RUN]
10:12:31  2 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_BLOCK_ID__NUMBER__FLOAT  [PASS in 6.30s]
10:12:31  7 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_TYPE__VARCHAR  [RUN]
10:12:31  1 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_ATTRIBUTES__OBJECT  [PASS in 6.34s]
10:12:31  8 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_TX_ID__VARCHAR  [RUN]
10:12:35  8 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_TX_ID__VARCHAR  [PASS in 3.87s]
10:12:35  9 of 20 START test dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_TX_SUCCEEDED__BOOLEAN  [RUN]
10:12:35  6 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_INDEX__NUMBER  [PASS in 4.21s]
10:12:35  10 of 20 START test dbt_utils_unique_combination_of_columns_silver__messages_message_id  [RUN]
10:12:35  5 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_ID__STRING__VARCHAR  [PASS in 4.43s]
10:12:35  11 of 20 START test not_null_silver__messages_ATTRIBUTES ....................... [RUN]
10:12:35  7 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_MESSAGE_TYPE__VARCHAR  [PASS in 4.19s]
10:12:35  12 of 20 START test not_null_silver__messages_BLOCK_ID ......................... [RUN]
10:12:38  9 of 20 PASS dbt_expectations_expect_column_values_to_be_in_type_list_silver__messages_TX_SUCCEEDED__BOOLEAN  [PASS in 3.64s]
10:12:38  13 of 20 START test not_null_silver__messages_BLOCK_TIMESTAMP .................. [RUN]
10:12:39  12 of 20 PASS not_null_silver__messages_BLOCK_ID ............................... [PASS in 4.19s]
10:12:39  14 of 20 START test not_null_silver__messages_CHAIN_ID ......................... [RUN]
10:12:39  10 of 20 PASS dbt_utils_unique_combination_of_columns_silver__messages_message_id  [PASS in 4.44s]
10:12:39  15 of 20 START test not_null_silver__messages_MESSAGE_ID ....................... [RUN]
10:12:41  11 of 20 PASS not_null_silver__messages_ATTRIBUTES ............................. [PASS in 6.26s]
10:12:41  16 of 20 START test not_null_silver__messages_MESSAGE_INDEX .................... [RUN]
10:12:42  13 of 20 PASS not_null_silver__messages_BLOCK_TIMESTAMP ........................ [PASS in 3.38s]
10:12:42  17 of 20 START test not_null_silver__messages_MESSAGE_TYPE ..................... [RUN]
10:12:43  14 of 20 PASS not_null_silver__messages_CHAIN_ID ............................... [PASS in 3.96s]
10:12:43  18 of 20 START test not_null_silver__messages_TX_ID ............................ [RUN]
10:12:43  15 of 20 PASS not_null_silver__messages_MESSAGE_ID ............................. [PASS in 3.94s]
10:12:43  19 of 20 START test not_null_silver__messages_TX_SUCCEEDED ..................... [RUN]
10:12:45  16 of 20 PASS not_null_silver__messages_MESSAGE_INDEX .......................... [PASS in 3.64s]
10:12:45  20 of 20 START test unique_silver__messages_MESSAGE_ID ......................... [RUN]
10:12:46  17 of 20 PASS not_null_silver__messages_MESSAGE_TYPE ........................... [PASS in 3.84s]
10:12:47  19 of 20 PASS not_null_silver__messages_TX_SUCCEEDED ........................... [PASS in 3.40s]
10:12:47  18 of 20 PASS not_null_silver__messages_TX_ID .................................. [PASS in 3.66s]
10:12:49  20 of 20 PASS unique_silver__messages_MESSAGE_ID ............................... [PASS in 4.37s]
10:12:49
10:12:49  Finished running 20 tests, 2 hooks in 0 hours 0 minutes and 45.71 seconds (45.71s).
10:12:49
10:12:49  Completed successfully
10:12:49
10:12:49  Done. PASS=20 WARN=0 ERROR=0 SKIP=0 TOTAL=20
```
- [x] Any comparison between `prod` and `dev` for any schema change
No changes


# Checklist
- [x] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [x] Tag the person(s) responsible for reviewing proposed changes @forgxyz 
- [x] Notes to deployment, if a `full-refresh` is needed for any table
- [x] Run `git merge main` to pull any changes from remote into your branch prior to merge.
