### PR TITLE
Changed json_merge types to object

### DIFF
--- a/macros/json_merge.sql
+++ b/macros/json_merge.sql
@@ -1,6 +1,6 @@
 {% macro create_json_merge() -%}
-CREATE OR REPLACE FUNCTION {{target.database}}.{{target.schema}}.json_merge(o1 VARIANT, o2 VARIANT)
-  RETURNS VARIANT
+CREATE OR REPLACE FUNCTION {{target.database}}.{{target.schema}}.json_merge(o1 OBJECT, o2 OBJECT)
+  RETURNS OBJECT
   LANGUAGE JAVASCRIPT
 AS
 $$


### PR DESCRIPTION
# Description

This pull request can potentially fix the error:

`JavaScript out of memory error: UDF thread memory limit exceeded`

# Tests

- [ ] Please provide evidence of your successful `dbt run` / `dbt test` here
- [ ] Any comparison between `prod` and `dev` for any schema change


# Checklist
- [ ] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [ ] Tag the person(s) responsible for reviewing proposed changes @forgxyz 
- [ ] Notes to deployment, if a `full-refresh` is needed for any table
- [ ] Run `git merge main` to pull any changes from remote into your branch prior to merge.
