### PR TITLE
utils dependency

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,4 +1,5 @@
 packages:
   - package: calogica/dbt_expectations
     version: [">=0.4.0", "<0.9.0"]
-    
+  - package: dbt-labs/dbt_utils
+    version: 0.9.2


### PR DESCRIPTION
The dbt utils package was deprecated from dbt core, and needs to be added as a standalone dependency.