### PR TITLE
Block validator list

### DIFF
--- a/models/core/core__fact_blocks.sql
+++ b/models/core/core__fact_blocks.sql
@@ -9,24 +9,32 @@ WITH blocks AS (
         *
     FROM
         {{ ref('silver__blocks') }}
+),
+final AS (
+
+    SELECT
+        block_id,
+        block_timestamp,
+        block_hash,
+        tx_count,
+        chain_id,
+        consensus_hash,
+        data_hash,
+        evidence,
+        evidence_hash,
+        block_height,
+        last_block_id,
+        last_commit,
+        last_commit_hash,
+        last_results_hash,
+        next_validators_hash,
+        proposer_address,
+        validators_hash,
+        validator_address_array,
+        _ingested_at,
+        _inserted_timestamp
+    FROM
+        blocks
 )
-SELECT
-    block_id,
-    block_timestamp,
-    block_hash,
-    tx_count,
-    chain_id,
-    consensus_hash,
-    data_hash,
-    evidence,
-    evidence_hash,
-    block_height,
-    last_block_id,
-    last_commit,
-    last_commit_hash,
-    last_results_hash,
-    next_validators_hash,
-    proposer_address,
-    validators_hash
-FROM
-    blocks
+
+SELECT * FROM final

--- a/models/core/core__fact_blocks.sql
+++ b/models/core/core__fact_blocks.sql
@@ -30,9 +30,7 @@ final AS (
         next_validators_hash,
         proposer_address,
         validators_hash,
-        validator_address_array,
-        _ingested_at,
-        _inserted_timestamp
+        validator_address_array
     FROM
         blocks
 )

--- a/models/core/core__fact_blocks.yml
+++ b/models/core/core__fact_blocks.yml
@@ -161,8 +161,11 @@ models:
       - name: VALIDATOR_ADDRESS_ARRAY
         description: "{{ doc('validator_address_array') }}"
         tests:
+          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
+                - ARRAY
                 - VARIANT
+                - OBJECT
 
 

--- a/models/core/core__fact_blocks.yml
+++ b/models/core/core__fact_blocks.yml
@@ -165,17 +165,4 @@ models:
               column_type_list:
                 - VARIANT
 
-      - name: _INGESTED_AT
-        description: "{{ doc('_ingested_at') }}"
-      #   tests:
-      #     - not_null
-
-      - name: _INSERTED_TIMESTAMP
-        description: "{{ doc('_inserted_timestamp') }}"
-      #   tests:
-      #     - not_null
-      #     - dbt_expectations.expect_column_values_to_be_in_type_list:
-      #         column_type_list:
-      #           - TIMESTAMP_NTZ
-
 

--- a/models/core/core__fact_blocks.yml
+++ b/models/core/core__fact_blocks.yml
@@ -157,3 +157,25 @@ models:
               column_type_list:
                 - STRING
                 - VARCHAR
+
+      - name: VALIDATOR_ADDRESS_ARRAY
+        description: "{{ doc('validator_address_array') }}"
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - VARIANT
+
+      - name: _INGESTED_AT
+        description: "{{ doc('_ingested_at') }}"
+      #   tests:
+      #     - not_null
+
+      - name: _INSERTED_TIMESTAMP
+        description: "{{ doc('_inserted_timestamp') }}"
+      #   tests:
+      #     - not_null
+      #     - dbt_expectations.expect_column_values_to_be_in_type_list:
+      #         column_type_list:
+      #           - TIMESTAMP_NTZ
+
+

--- a/models/descriptions/validator_address.md
+++ b/models/descriptions/validator_address.md
@@ -1,3 +1,4 @@
+
 {% docs validator_address %}
 
 The address of the validator who validate the delegation

--- a/models/descriptions/validator_address_array.md
+++ b/models/descriptions/validator_address_array.md
@@ -1,6 +1,6 @@
 
 {% docs validator_address_array %}
 
-Determines whether the transfer is coming from one blockchain to another or vice versa.
+An array of all validators that voted on the block.
 
 {% enddocs %}

--- a/models/descriptions/validator_address_array.md
+++ b/models/descriptions/validator_address_array.md
@@ -1,0 +1,6 @@
+
+{% docs validator_address_array %}
+
+Determines whether the transfer is coming from one blockchain to another or vice versa.
+
+{% enddocs %}

--- a/models/silver/silver__blocks.sql
+++ b/models/silver/silver__blocks.sql
@@ -79,7 +79,7 @@ FINAL AS (
         base_blocks.header :validators_hash :: STRING AS validators_hash,
         base_blocks._ingested_at AS _ingested_at,
         base_blocks._inserted_timestamp AS _inserted_timestamp,
-        validators_address_array.address_array AS validator_address_array
+        validators_address_array.address_array :: ARRAY AS validator_address_array
     FROM
         base_blocks
     LEFT JOIN validators_address_array 

--- a/models/silver/silver__blocks.sql
+++ b/models/silver/silver__blocks.sql
@@ -52,7 +52,7 @@ validator_addresses as (
 ),
 validators_address_array as (
     SELECT
-        validator_addresses.block_id as block_id,
+        CAST(validator_addresses.block_id AS NUMBER(38,0)) as block_id,
         ARRAY_AGG(distinct validator_addresses.validator_address) as address_array
     FROM
         validator_addresses

--- a/models/silver/silver__blocks.yml
+++ b/models/silver/silver__blocks.yml
@@ -8,7 +8,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - block_id
-
     columns:
       - name: BLOCK_ID
         description: "{{ doc('block_id')}}"
@@ -159,6 +158,14 @@ models:
               column_type_list:
                 - STRING
                 - VARCHAR
+
+      - name: VALIDATOR_ADDRESS_ARRAY
+        description: "{{ doc('validator_address_array') }}"
+        # description: "Array of validators that voted on the block"
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - VARIANT
 
       - name: _INGESTED_AT
         description: "{{ doc('_ingested_at')}}"

--- a/models/silver/silver__blocks.yml
+++ b/models/silver/silver__blocks.yml
@@ -161,8 +161,8 @@ models:
 
       - name: VALIDATOR_ADDRESS_ARRAY
         description: "{{ doc('validator_address_array') }}"
-        # description: "Array of validators that voted on the block"
         tests:
+          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - VARIANT

--- a/models/silver/silver__blocks.yml
+++ b/models/silver/silver__blocks.yml
@@ -165,7 +165,9 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
+                - ARRAY
                 - VARIANT
+                - OBJECT
 
       - name: _INGESTED_AT
         description: "{{ doc('_ingested_at')}}"


### PR DESCRIPTION
# Description
Added array of validator addresses for each block to conform to IBC standards. This adds a column to silver_blocks & core__fact_blocks. A column is added so --full-refresh is needed.

silver_blocks: 
    - Added CTEs (validator_signatures, validator_addresses, and validator_address_array) to get validator addresses from the header.
    - Joined the validator address array in validator_address_array on base_blocks.

core__fact_blocks:
    - Appended validator_address_array column to model

descriptions:
    - Added description file for validator_address_array 
_Please include a summary of changes and related issue (if any)._


# Tests

- [x] Please provide evidence of your successful `dbt run` / `dbt test` here
![dbt_run_screenshot](https://user-images.githubusercontent.com/85205238/205156780-fc224775-e48e-4593-9730-a792840e426d.png)

- [ ] Any comparison between `prod` and `dev` for any schema change

# Checklist
- [x] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [x] Run `git merge main` to pull any changes from remote into your branch prior to merge.
- [x] Tag the person(s) responsible for reviewing proposed changes
- [x] **IMPORTANT** Note for deployment if a `full-refresh` is needed for any model this PR impacts.
     - If any schema is changing, 

whether it be a table or a view, we will need to run a `full-refresh` in prod to avoid errors with the scheduled refresh jobs.
     - The PR can be reviewed, but should not be merged unless by someone with prod access.
         - Tag `forgxyz` if a full-refresh will be required on prod.
