### PR TITLE
hardcode test

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,5 +1,5 @@
 packages:
   - package: calogica/dbt_expectations
-    version: [">=0.4.0", "<0.9.0"]
+    version: 0.8.0
   - package: dbt-labs/dbt_utils
     version: 0.9.6


### PR DESCRIPTION
Sets dbt expectations version to 0.8.0 as 0.8.1 includes a breaking change to the recency test we use