### PR TITLE
fix addr labels

### DIFF
--- a/models/core/core__dim_address_labels.sql
+++ b/models/core/core__dim_address_labels.sql
@@ -20,6 +20,13 @@ WITH labels AS (
         ) }}
     WHERE
         blockchain = 'terra'
+        AND address != 'flipside' 
+        
+        qualify ROW_NUMBER() over (
+            PARTITION BY address
+            ORDER BY
+                creator DESC
+        ) = 1
 ),
 tokens AS (
     SELECT
@@ -48,15 +55,15 @@ FINAL AS (
             l.creator
         ) AS creator,
         IFF(
-            l.label_type is not null,
+            l.label_type IS NOT NULL,
             l.label_type,
-            'token') AS label_type,
+            'token'
+        ) AS label_type,
         IFF(
-            l.label_subtype is not null,
-        l.label_subtype,
-        'token_contract'
-        ) as label_subtype
-        ,
+            l.label_subtype IS NOT NULL,
+            l.label_subtype,
+            'token_contract'
+        ) AS label_subtype,
         COALESCE(
             t.symbol,
             l.label

--- a/models/core/core__dim_address_labels.sql
+++ b/models/core/core__dim_address_labels.sql
@@ -9,13 +9,13 @@ WITH labels AS (
         blockchain,
         address,
         creator,
-        l1_label AS label_type,
-        l2_label AS label_subtype,
+        label_type,
+        label_subtype,
         address_name AS label,
         project_name
     FROM
         {{ source(
-            'labels',
+            'labels_v2',
             'address_labels'
         ) }}
     WHERE

--- a/models/core/core__dim_address_labels.sql
+++ b/models/core/core__dim_address_labels.sql
@@ -20,7 +20,7 @@ WITH labels AS (
         ) }}
     WHERE
         blockchain = 'terra'
-        AND address != 'flipside' 
+        and delete_flag is null
         
         qualify ROW_NUMBER() over (
             PARTITION BY address

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -131,3 +131,8 @@ sources:
     database: flipside_prod_db
     tables:
       - name: address_labels
+  - name: labels_v2
+    schema: silver
+    database: crosschain
+    tables:
+      - name: address_labels


### PR DESCRIPTION
# Description

_Please include a summary of changes and related issue (if any)._
Changes the source for labels from a legacy table to the active one.

# Tests

- [x] Please provide evidence of your successful `dbt run` / `dbt test` here
- [x] Any comparison between `prod` and `dev` for any schema change
Recency failure is expected
```
Finished running 18 tests, 3 hooks in 0 hours 0 minutes and 30.90 seconds (30.90s).      
19:30:18  
19:30:18  Completed with 1 error and 0 warnings:
19:30:18
19:30:18  Failure in test dbt_expectations_expect_row_values_to_have_recent_data_core__ez_staking_BLOCK_TIMESTAMP__day__1 (models/core/core__ez_staking.yml)
19:30:18    Got 1 result, configured to fail if != 0
19:30:18
19:30:18    compiled Code at target/compiled/terra/models/core/core__ez_staking.yml/dbt_expectations_expect_row_va_867847b1d0784a4d79f1c6468dd72d0f.sql
19:30:18
19:30:18    See test failures:
  --------------------------------------------------------------------------------------------------------------
  select * from TERRA_DEV.dbt_expectations_expect_row_values_to_have_recent_data_core.ez_staking_BLOCK_TIMESTAMP
  --------------------------------------------------------------------------------------------------------------
19:30:18
19:30:18  Done. PASS=17 WARN=0 ERROR=1 SKIP=0 TOTAL=18
```
# Checklist
- [x] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [x] Run `git merge main` to pull any changes from remote into your branch prior to merge.
- [x] Tag the person(s) responsible for reviewing proposed changes
- [x] **IMPORTANT** Note for deployment if a `full-refresh` is needed for any model this PR impacts.
     - If any schema is changing, whether it be a table or a view, we will need to run a `full-refresh` in prod to avoid errors with the scheduled refresh jobs.
     - The PR can be reviewed, but should not be merged unless by someone with prod access.
         - Tag `forgxyz` if a full-refresh will be required on prod.
